### PR TITLE
feat(CYD-143): Add agent lifecycle HTTP endpoints

### DIFF
--- a/convex/http.ts
+++ b/convex/http.ts
@@ -1,7 +1,10 @@
 import { httpRouter } from "convex/server";
 import { ingest } from "./events";
 import {
+  completeAgentLifecycleHttp,
+  heartbeatAgentLifecycleHttp,
   listWorkingMemoryHttp,
+  startAgentLifecycleHttp,
   syncAgentMetadataHttp,
   updateAgentStatusHttp,
   upsertWorkingMemoryHttp,
@@ -42,6 +45,24 @@ http.route({
   path: "/agents/working-memory",
   method: "GET",
   handler: listWorkingMemoryHttp,
+});
+
+http.route({
+  path: "/agent/start",
+  method: "POST",
+  handler: startAgentLifecycleHttp,
+});
+
+http.route({
+  path: "/agent/heartbeat",
+  method: "POST",
+  handler: heartbeatAgentLifecycleHttp,
+});
+
+http.route({
+  path: "/agent/complete",
+  method: "POST",
+  handler: completeAgentLifecycleHttp,
 });
 
 http.route({


### PR DESCRIPTION
## Summary
Implements agent lifecycle HTTP endpoints for the spawn wrapper to register agent activity.

## Endpoints Added
- **POST /agent/start** - Register agent as active when work begins
- **POST /agent/heartbeat** - Update working memory during execution
- **POST /agent/complete** - Mark agent as completed when work finishes

## Implementation Details
- Bridge auth using BRIDGE_SECRET
- Status updates (busy → online/idle)
- Working memory sync
- Session tracking
- Completion event logging

## Testing
- Added tests in `convex/agents.test.ts`
- All tests pass: `npx vitest run convex/agents.test.ts`

## Related
- Linear: CYD-143
- Enables: Agent spawn wrapper script (CYD-142)

Implemented by Codex CLI in YOLO mode 🤖